### PR TITLE
Typo in documentation: warning box

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -1298,7 +1298,7 @@
                 <label for="code-10">Code</label>
                 <div class="container to-code">
                     &lt;body>
-                    <div class="box notice"><i class="ico-warning"></i>Message</div>
+                    <div class="box warning"><i class="ico-warning"></i>Message</div>
                     ...
                 </div>
             </div>


### PR DESCRIPTION
"box notice" should be "box warning" for warning boxes